### PR TITLE
Update ncbi_get_meta()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,6 @@ LazyData: true
 Imports:
     curl,
     dplyr,
-    genbankr,
     httr,
     jsonlite,
     plyr,

--- a/R/examples.R
+++ b/R/examples.R
@@ -3,13 +3,14 @@
 #' This data set contains a list of IDs which can be used to access data from
 #' various data sources. These IDs are used across the package in function
 #' documentations, tests, vignettes.
+#' 
 #' @format A list with 6 elements:
 #' \describe{
 #'   \item{assembly}{NCBI Assembly IDs}
 #'   \item{bioproject}{NCBI BioProject IDs}
 #'   \item{biosample}{NCBI BioSample IDs}
-#'   \item{gene} {NCBI Gene IDs}
-#'   \item{protein} {NCBI Protein IDs}
+#'   \item{gene}{NCBI Gene IDs}
+#'   \item{protein}{NCBI Protein IDs}
 #'   \item{sra}{NCBI SRA IDs}
 #' }
 "examples"

--- a/R/ncbi_get_meta.R
+++ b/R/ncbi_get_meta.R
@@ -1,7 +1,8 @@
 #' Get sequence metadata from NCBI
 #' 
 #' This function retrieves metadata from a given NCBI sequence database.
-#' @param term character; one or more search terms.
+#' @param query either an object of class \code{ncbi_uid} or an integer vector 
+#' of UIDs. See Details for more information.
 #' @param db character; the database to search in. For options see
 #' \code{ncbi_dbs()}. Not all databases are supported.
 #' @param batch_size integer; the number of search terms to query at once. If
@@ -19,28 +20,55 @@
 #' \code{parse = FALSE} the unparsed metadata.
 #' \item \code{history}: a tibble of web histories.
 #' }
+#' @details Some functions in webseq, e.g. \code{ncbi_get_uid()} or
+#' \code{ncbi_link_uid()} return objects of class \code{"ncbi_uid"}. These
+#' objects may be used directly as query input for \code{ncbi_get_meta()}. This
+#' approach is recommended because the internal structure of these objects make
+#' \code{ncbi_get_meta()} queries more robust. Alternatively, you can also
+#' use a character vector of UIDs as query input.
+#' @details If query is a \code{"ncbi_uid"} object, the \code{db} argument is
+#' optional. If \code{db} is not specified, the function will use the
+#' \code{db} attribute of the \code{"ncbi_uid"} object as \code{db} argument.
+#' However, if it is specified, it must be identical to the \code{db} attribute
+#' of the \code{"ncbi_uid"} object. If query is a character vector, the
+#' \code{db} argument is required.
 #' @examples
 #' \dontrun{
 #' data(examples)
-#' meta <- ncbi_get_meta(examples$biosample, db = "biosample")
+#' uids <- ncbi_get_uid(examples$biosample, db = "biosample")
+#' meta <- ncbi_get_meta(uids)
 #' }
 #' @export
 ncbi_get_meta <- function(
-    term,
-    db,
+    query,
+    db = NULL,
     batch_size = 100,
     use_history = TRUE,
     parse = TRUE,
     verbose = getOption("verbose")
   ) {
+  if ("ncbi_uid" %in% class(query)) {
+    if (is.null(db)) {
+      db <- query$db
+    } else {
+      if (db != query$db) {
+        msg <- paste0(
+          "Database for queried UIDs does not match 'from' argument.\n",
+          "Provide identical values or use from = NULL (default)."
+        )
+        stop(msg)
+      }
+    }
+  } else {
+    if (is.null(db)) {
+      msg <- paste0(
+        "Specify a 'db' argument ",
+        "or use an object of class 'ncbi_uid' as query."
+      )
+      stop(msg)
+    }
+  }
   db <- match.arg(db, choices = ncbi_dbs())
-  uid <- ncbi_get_uid(
-    term = term,
-    db = db,
-    batch_size = batch_size,
-    use_history = use_history,
-    verbose = verbose
-  )
   rettype <- switch(
     db,
     assembly = "docsum",
@@ -52,64 +80,75 @@ ncbi_get_meta <- function(
     sra = "full"
   )
   retmode <- "xml"
-  if (use_history) {
-    res <- lapply(1:nrow(uid$web_history), function(x) {
-      WH <- list(
-      "WebEnv" = uid$web_history$WebEnv[x],
-      "QueryKey" = uid$web_history$QueryKey[x]
-      )
-      wrap(
-        "entrez_fetch",
-        package = "rentrez",
-        db = db,
-        web_history = WH,
-        rettype = rettype,
-        retmode = retmode,
-        verbose = verbose
-      ) 
-    })
+  foo_from_histories <- function(x, db) {
+    WH <- list(
+      "WebEnv" = query$web_history$WebEnv[x],
+      "QueryKey" = query$web_history$QueryKey[x]
+    )
+    class(WH) <- c("web_history", "list")
+    res <- wrap(
+      "entrez_fetch",
+      package = "rentrez",
+      db = db,
+      web_history = WH,
+      rettype = rettype,
+      retmode = retmode,
+      verbose = verbose
+    )
+    return(res)
+  }
+  foo_from_ids <- function(x, db) {
+    res <- wrap(
+      "entrez_fetch",
+      package = "rentrez",
+      db = db,
+      id = x,
+      rettype = rettype,
+      retmode = retmode,
+      verbose = verbose
+    )
+    return(res)
+  }
+  if ("ncbi_uid" %in% class(query) & use_history) {
+    if (nrow(query$web_history) > 0) {
+      if (verbose) message("Using web history.")
+      res <- lapply(1:nrow(query$web_history), function(x) {
+        foo_from_histories(x, db = db)
+      })
+    } else {
+      if (verbose) message("No web history found.")
+      idlist <- get_idlist(query$uid, batch_size, verbose)
+      res <- lapply(idlist, function(x) {
+        foo_from_ids(x, db)
+      })
+    }
   } else {
-    idlist <- get_idlist(uid$uid, batch_size, verbose)
+    if ("ncbi_uid" %in% class(query)) {
+      query <- query$uid
+    }
+    idlist <- get_idlist(query, batch_size, verbose)
     res <- lapply(idlist, function(x) {
-      wrap(
-        "entrez_fetch",
-        package = "rentrez",
-        db = db,
-        id = x,
-        rettype = rettype,
-        retmode = retmode,
-        verbose = verbose
-      )
+      foo_from_ids(x, db = db)
     })
   }
   if (parse) {
     if (verbose) {
-      message("Attempting to parse retrieved metadata.")
+      message("Attempting to parse retrieved metadata.", appendLF = FALSE)
     }
     res_parsed <- lapply(res, function(x) {
       ncbi_parse(meta = x, db = db, verbose = verbose)
     })
     if ("data.frame" %in% class(res_parsed[[1]])) {
-      res_parsed <- dplyr::bind_rows(res_parsed)
+      if (verbose) message(" Done.")
+      out <- dplyr::bind_rows(res_parsed)
     } else {
-      res_parsed <- res
+      if (verbose) message(" Failed.")
+      out <- res
     }
   } else {
-    res_parsed <- res
+    out <- res
   }
-  if (use_history) {
-    out <- list(
-      meta = res_parsed,
-      db = db,
-      web_history = uid$web_history
-    )
-  } else {
-    out <- list(
-      meta = res_parsed,
-      db = db,
-      web_history = NULL
-    )
-  }
+  attr(out, "db") = db
   class(out) <- c("ncbi_meta", class(out))
   validate_webseq_class(out)
   return(out)

--- a/R/ncbi_link_uid.R
+++ b/R/ncbi_link_uid.R
@@ -4,7 +4,7 @@
 #' different databases may be linked. For example, entries in the NCBI Assembly
 #' database may be linked with entries in the NCBI BioSample database. This
 #' function attempts to link uids from one database to another.
-#' @param query either an object of class \code{ncnbi_uid} or an integer vector 
+#' @param query either an object of class \code{ncbi_uid} or an integer vector 
 #' of UIDs. See Details for more information.
 #' @param to character; the database in which the function should look for links.
 #' \code{ncbi_dbs()} lists all available options. See Details for more
@@ -32,7 +32,7 @@
 #' approach is recommended because the internal structure of these objects make
 #' \code{ncbi_link_uid()} queries more robust. Alternatively, you can also
 #' use a character vector of UIDs as query input.
-#' @details If query is a \code{"ncbi_uid} object, the \code{from} argument is
+#' @details If query is a \code{"ncbi_uid"} object, the \code{from} argument is
 #' optional. If \code{from} is not specified, the function will use the
 #' \code{db} attribute of the \code{"ncbi_uid"} object as \code{from} argument.
 #' However, if it is specified, it must be identical to the \code{db} attribute
@@ -58,8 +58,7 @@ ncbi_link_uid <- function(
     } else {
       if (from != query$db) {
         msg <- paste0(
-          "Database for queried UIDs does not match 'from' argument.",
-          "\n",
+          "Database for queried UIDs does not match 'from' argument.\n",
           "Provide identical values or use from = NULL (default)."
         )
         stop(msg)
@@ -68,7 +67,7 @@ ncbi_link_uid <- function(
   } else {
     if (is.null(from)) {
       msg <- paste0(
-        "Specify a from argument ",
+        "Specify a 'from' argument ",
         "or use an object of class 'ncbi_uid' as query."
       )
       stop(msg)
@@ -105,7 +104,7 @@ ncbi_link_uid <- function(
       (length(wh_hit) == 1 && is.na(wh_hit))
       ) {
       return(list(
-        uid = NA_integer,
+        uid = NA_integer_,
         db = to,
         web_history = tibble::tibble()
       ))
@@ -145,7 +144,7 @@ ncbi_link_uid <- function(
       (length(wh_hit) == 1 && is.na(wh_hit))
       ) {
       return(list(
-        uid = NA_integer,
+        uid = NA_integer_,
         db = to,
         web_history = tibble::tibble()
       ))
@@ -175,7 +174,7 @@ ncbi_link_uid <- function(
       })
     } else {
       if (verbose) message("No web history found.")
-      idlist <- get_idlist(query, batch_size, verbose)
+      idlist <- get_idlist(query$uid, batch_size, verbose)
       res <- lapply(idlist, function(x) {
         foo_from_ids(
           x,
@@ -189,12 +188,6 @@ ncbi_link_uid <- function(
     if (verbose) message("Not using web history.")
     if ("ncbi_uid" %in% class(query)) {
       query <- query$uid
-    }
-    if (all(is.na(query))) {
-      stop("No valid search terms.")
-    } else if (any(is.na(query))){
-      if (verbose) message("Removing NA-s from search terms.")
-      query <- query[which(!is.na(query))]
     }
     idlist <- get_idlist(query, batch_size, verbose)
     res <- lapply(idlist, function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -102,13 +102,20 @@ wrap <- function(
 #' @param verbose logical; Should verbose messages be printed to console?
 #' @noRd
 get_idlist <- function(ids, batch_size, verbose = getOption("verbose")) {
+  ids <- as.numeric(ids)
+  if (all(is.na(ids))) {
+    stop("No valid IDs.")
+  } else if (any(is.na(ids))){
+    if (verbose) message("Removing NA-s from IDs.")
+    ids <- ids[which(!is.na(ids))]
+  }
   idlist <- list()
   if (length(ids) > batch_size) {
     nbatch <- ceiling(length(ids)/batch_size)
     if (verbose) message("Splitting ids into ", nbatch, " batches.")
     for (i in 1:nbatch) {
       index_min <- (i-1)*batch_size + 1
-      index_max <- min(i*batch_size, length(query))
+      index_max <- min(i*batch_size, length(ids))
       idlist[[i]] <- ids[index_min:index_max]
     }
   } else {
@@ -129,17 +136,9 @@ validate_webseq_class <- function(x) {
     testthat::expect_true(names(x)[3] == "web_history")
     testthat::expect_true(class(x$uid) == "integer")
     testthat::expect_true(class(x$db) == "character")
-    expect_s3_class(x$web_history, c("tbl_df", "tbl", "data.frame"))
+    testthat::expect_s3_class(x$web_history, c("tbl_df", "tbl", "data.frame"))
   }
   if ("ncbi_meta" %in% class(x)) {
-    testthat::expect_equal(length(names(x)), 3)
-    testthat::expect_true(names(x)[1] == "meta")
-    testthat::expect_true(names(x)[2] == "db")
-    testthat::expect_true(names(x)[3] == "web_history")
-    testthat::expect_true(
-      any(c("character", "tbl_df") %in% class(x$web_history))
-    )
-    testthat::expect_true(class(x$db) == "character")
-    expect_s3_class(x$web_history, c("tbl_df", "tbl", "data.frame"))
+    testthat::expect_true(attr(x, "db") %in% ncbi_dbs())
   }
 }

--- a/man/examples.Rd
+++ b/man/examples.Rd
@@ -10,8 +10,8 @@ A list with 6 elements:
   \item{assembly}{NCBI Assembly IDs}
   \item{bioproject}{NCBI BioProject IDs}
   \item{biosample}{NCBI BioSample IDs}
-  \item{gene} {NCBI Gene IDs}
-  \item{protein} {NCBI Protein IDs}
+  \item{gene}{NCBI Gene IDs}
+  \item{protein}{NCBI Protein IDs}
   \item{sra}{NCBI SRA IDs}
 }
 }

--- a/man/ncbi_get_meta.Rd
+++ b/man/ncbi_get_meta.Rd
@@ -5,8 +5,8 @@
 \title{Get sequence metadata from NCBI}
 \usage{
 ncbi_get_meta(
-  term,
-  db,
+  query,
+  db = NULL,
   batch_size = 100,
   use_history = TRUE,
   parse = TRUE,
@@ -14,7 +14,8 @@ ncbi_get_meta(
 )
 }
 \arguments{
-\item{term}{character; one or more search terms.}
+\item{query}{either an object of class \code{ncbi_uid} or an integer vector 
+of UIDs. See Details for more information.}
 
 \item{db}{character; the database to search in. For options see
 \code{ncbi_dbs()}. Not all databases are supported.}
@@ -43,9 +44,25 @@ metadata or if parsing is unsuccessful, the unparsed metadata. If
 \description{
 This function retrieves metadata from a given NCBI sequence database.
 }
+\details{
+Some functions in webseq, e.g. \code{ncbi_get_uid()} or
+\code{ncbi_link_uid()} return objects of class \code{"ncbi_uid"}. These
+objects may be used directly as query input for \code{ncbi_get_meta()}. This
+approach is recommended because the internal structure of these objects make
+\code{ncbi_get_meta()} queries more robust. Alternatively, you can also
+use a character vector of UIDs as query input.
+
+If query is a \code{"ncbi_uid"} object, the \code{db} argument is
+optional. If \code{db} is not specified, the function will use the
+\code{db} attribute of the \code{"ncbi_uid"} object as \code{db} argument.
+However, if it is specified, it must be identical to the \code{db} attribute
+of the \code{"ncbi_uid"} object. If query is a character vector, the
+\code{db} argument is required.
+}
 \examples{
 \dontrun{
 data(examples)
-meta <- ncbi_get_meta(examples$biosample, db = "biosample")
+uids <- ncbi_get_uid(examples$biosample, db = "biosample")
+meta <- ncbi_get_meta(uids)
 }
 }

--- a/man/ncbi_link_uid.Rd
+++ b/man/ncbi_link_uid.Rd
@@ -14,7 +14,7 @@ ncbi_link_uid(
 )
 }
 \arguments{
-\item{query}{either an object of class \code{ncnbi_uid} or an integer vector 
+\item{query}{either an object of class \code{ncbi_uid} or an integer vector 
 of UIDs. See Details for more information.}
 
 \item{from}{character; the database the queried UIDs come from.
@@ -58,7 +58,7 @@ approach is recommended because the internal structure of these objects make
 \code{ncbi_link_uid()} queries more robust. Alternatively, you can also
 use a character vector of UIDs as query input.
 
-If query is a \code{"ncbi_uid} object, the \code{from} argument is
+If query is a \code{"ncbi_uid"} object, the \code{from} argument is
 optional. If \code{from} is not specified, the function will use the
 \code{db} attribute of the \code{"ncbi_uid"} object as \code{from} argument.
 However, if it is specified, it must be identical to the \code{db} attribute

--- a/tests/testthat/test-ncbi_link_uid.R
+++ b/tests/testthat/test-ncbi_link_uid.R
@@ -72,3 +72,9 @@ test_that("ncbi_link_uid() can use an ncbi_uid object's db element", {
   expect_true(all(c("ncbi_uid", "list") %in% class(biosample_uid)))
   expect_true(all(biosample_uid$uid %in% c("2952905", "1730125")))
 })
+
+test_that("ncbi_link_uid() fails if input is invalid", {
+  expect_error(suppressWarnings(
+    ncbi_link_uid("funky", from = "assembly", to = "biosample")
+  ))
+})

--- a/tests/testthat/test-ncbi_parse.R
+++ b/tests/testthat/test-ncbi_parse.R
@@ -1,10 +1,8 @@
 test_that("ncbi_parse() works with BioSamples", {
   data(examples)
-  biosample_uid <- ncbi_get_uid(examples$biosample, db = "biosample")
-  meta_xml <- suppressWarnings(
-    ncbi_get_meta(examples$biosample[1], db = "biosample", parse = FALSE)
-  )
-  res <- ncbi_parse(meta = meta_xml$meta, db = "biosample", format = "xml")
+  biosample_uid <- ncbi_get_uid(examples$biosample[1], db = "biosample")
+  meta_xml <- suppressWarnings(ncbi_get_meta(biosample_uid, parse = FALSE))
+  res <- ncbi_parse(meta = meta_xml[[1]], db = "biosample", format = "xml")
   expect_s3_class(res, c("tbl_df", "tbl", "data.frame"))
   expect_equal(res$biosample[1], "SAMN02714232")
 })


### PR DESCRIPTION
Related to Issue #21, Issue #26, Issue #41, Issue #42.

* `ncbi_get_meta()` no longer accepts search terms, it requires either a vector of uids or an ncbi_uid object. This updated removes the embedded `ncbi_get_uid()` call and decouples the two functions which makes `ncbi_get_meta()` more flexible.
*  `ncbi_get_meta()` now includes more verbose messages.
* the utility function `get_idlist()` now attempts to coerce ids to numeric and fails if all ids become NAs. This currently impacts two UID using functions, `ncbi_link_uid()` and `ncbi_get_meta()`.