### PR TITLE
Do not use web histories by default with ncbi_link_uid()

### DIFF
--- a/R/ncbi_get_uid.R
+++ b/R/ncbi_get_uid.R
@@ -35,6 +35,7 @@ ncbi_get_uid <- function(
     db,
     batch_size = 100,
     use_history = TRUE,
+    retmax = 9999,
     verbose = getOption("verbose")
     ) {
   db <- match.arg(db, choices = ncbi_dbs())
@@ -60,24 +61,24 @@ ncbi_get_uid <- function(
   })
   foo <- function(x) {
     if (verbose) message("Querying UIDs for batch ", x, ". ", appendLF = FALSE)
-    hit <- wrap(
-      "entrez_search",
-      package = "rentrez",
-      verbose = verbose,
-      db = db,
-      term = termlist[[x]],
-      use_history = use_history
-    )
-    if (hit$count > hit$retmax) {
-      hit <- wrap(
+    hit <- list()
+    k <- 1
+    while(k > 0) {
+      hit[[k]] <- wrap(
         "entrez_search",
         package = "rentrez",
         verbose = verbose,
         db = db,
         term = termlist[[x]],
         use_history = use_history,
-        retmax = hit$count
+        retstart = (k-1)*retmax,
+        retmax = retmax
       )
+      if (hit[[k]]$count > k*retmax) {
+        k = k + 1
+      } else {
+        k = 0
+      }
     }
     if (length(hit) == 1 && is.na(hit)) {
       return(list(
@@ -85,25 +86,22 @@ ncbi_get_uid <- function(
         db = db,
         web_history = tibble::tibble()
       ))
-    } else if (length(hit$ids) == 0) {
+    } else if (length(hit) == 1 && length(hit$ids) == 0) {
       if (verbose) message("Term not found. Returning NA.")
       return(list(
         uid = NA_integer_,
         db = db,
         web_history = tibble::tibble()
       ))
-    } else if (length(hit$ids) > 0) {
-      return(list(
-        uid = as.integer(hit$ids),
-        db = db,
-        web_history = hit$web_history
-      ))
     } else {
-      if (verbose) message("Unknown exception.")
+      uid <- lapply(hit, function(x) x$ids)
+      uid <- as.integer(unlist(uid))
+      web_history <- lapply(hit, function(x) x$web_history)
+      web_history <- dplyr::bind_rows(web_history)
       return(list(
-        uid = NA_integer_,
+        uid = uid,
         db = db,
-        web_history = tibble::tibble()
+        web_history = web_history
       ))
     }
   }

--- a/R/ncbi_link_uid.R
+++ b/R/ncbi_link_uid.R
@@ -38,6 +38,9 @@
 #' However, if it is specified, it must be identical to the \code{db} attribute
 #' of the \code{"ncbi_uid"} object. If query is a character vector, the
 #' \code{from} argument is required.
+  #' @note \code{ncbi_link_uid()} can work with or without web histories, but the
+#' behaviour of the function with web histories is unreliable. The option is
+#' there but it is recommended NOT to use web histories with this function.
 #' @examples
 #' \dontrun{
 #' ncbi_link_uid("4253631", "assembly", "biosample")
@@ -49,7 +52,7 @@ ncbi_link_uid <- function(
     from = NULL,
     to,
     batch_size = 100,
-    use_history = TRUE,
+    use_history = FALSE,
     verbose = getOption("verbose")
     ) {
   if ("ncbi_uid" %in% class(query)) {

--- a/man/ncbi_link_uid.Rd
+++ b/man/ncbi_link_uid.Rd
@@ -9,7 +9,7 @@ ncbi_link_uid(
   from = NULL,
   to,
   batch_size = 100,
-  use_history = TRUE,
+  use_history = FALSE,
   verbose = getOption("verbose")
 )
 }
@@ -64,6 +64,11 @@ optional. If \code{from} is not specified, the function will use the
 However, if it is specified, it must be identical to the \code{db} attribute
 of the \code{"ncbi_uid"} object. If query is a character vector, the
 \code{from} argument is required.
+}
+\note{
+\code{ncbi_link_uid()} can work with or without web histories, but the
+behaviour of the function with web histories is unreliable. The option is
+there but it is recommended NOT to use web histories with this function.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-ncbi_link_uid.R
+++ b/tests/testthat/test-ncbi_link_uid.R
@@ -4,7 +4,7 @@ test_that("ncbi_link_uid() converts using input history", {
   # input is ncbi_uid object with history
   assembly_uid <- ncbi_get_uid(examples$assembly, db = "assembly")
   biosample_uid <- ncbi_link_uid(
-    assembly_uid, from = "assembly", to = "biosample"
+    assembly_uid, from = "assembly", to = "biosample", use_history = TRUE
   )
   expect_true(all(c("ncbi_uid", "list") %in% class(biosample_uid)))
   expect_true(all(biosample_uid$uid %in% c("2952905", "1730125")))


### PR DESCRIPTION
Related to Issue #26, Issue #34.

Web histories seem to be unreliable with `ncbi_link_uid()`. The root of the problem is currently unclear, until this is resolved, I'm just adjusting `ncbi_link_uid()` not to use web histories by default.