### PR TITLE
Stricter input validation for ncbi_link_uid()

### DIFF
--- a/R/ncbi_db_links.R
+++ b/R/ncbi_db_links.R
@@ -1,0 +1,28 @@
+#' Which NCBI databases can an database be linked to?
+#'
+#' This function is a wrapper around \code{rentrez::entrez_db_links()}. Results
+#' are cached and reused to validate input for \code{ncbi_link_uid()}.
+#' @param db character; the name of an NCBI database
+#' @return a character vector of NCBI database names the original database can
+#' be linked to.
+#' @examples
+#' \dontrun{
+#' ncbi_db_links("assembly")
+#' }
+#' @noRd
+ncbi_db_links <- function(db) {
+  if (!dir.exists(tempdir())) dir.create(tempdir())
+  filename <- paste0(
+    tempdir(),
+    "/webseq_ncbi_db_links_",
+    db,
+    ".rds"
+  )
+  if (!file.exists(filename)) {
+    db_links <- names(rentrez::entrez_db_links(db))
+    saveRDS(db_links, file = filename)
+  } else {
+    db_links <- readRDS(filename)
+  }
+  return(db_links)
+}

--- a/R/ncbi_dbs.R
+++ b/R/ncbi_dbs.R
@@ -1,10 +1,10 @@
 ncbi_dbs <- function() {
   if (!dir.exists(tempdir())) dir.create(tempdir())
-  if (!file.exists(paste0(tempdir(), "/webseq.rds"))) {
+  if (!file.exists(paste0(tempdir(), "/webseq_ncbi_dbs.rds"))) {
     dbs <- rentrez::entrez_dbs()
-    saveRDS(dbs, file = paste0(tempdir(), "/webseq.rds"))
+    saveRDS(dbs, file = paste0(tempdir(), "/webseq_ncbi_dbs.rds"))
   } else {
-    dbs <- readRDS(paste0(tempdir(), "/webseq.rds"))
+    dbs <- readRDS(paste0(tempdir(), "/webseq_ncbi_dbs.rds"))
   }
   return(dbs)
 }

--- a/R/ncbi_link_uid.R
+++ b/R/ncbi_link_uid.R
@@ -77,7 +77,7 @@ ncbi_link_uid <- function(
     }
   }
   from <- match.arg(from, ncbi_dbs())
-  to <- match.arg(to, ncbi_dbs())
+  to <- match.arg(to, ncbi_db_links(from))
   foo_from_histories <- function(x, from, to) {
     WH <- list(
       "WebEnv" = query$web_history$WebEnv[x],

--- a/README.Rmd
+++ b/README.Rmd
@@ -30,7 +30,7 @@ Currently `webseq` can interact with the following web services:
 
 * NCBI: https://www.ncbi.nlm.nih.gov/
 * ENA: https://www.ebi.ac.uk/ena/browser/home
-* MGnify: https://www.ebi.ac.uk/ena/browser/home
+* MGnify: https://www.ebi.ac.uk/metagenomics
 
 The package is under development, some of the functionality may be very limited at this point.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Currently `webseq` can interact with the following web services:
 
 - NCBI: <https://www.ncbi.nlm.nih.gov/>
 - ENA: <https://www.ebi.ac.uk/ena/browser/home>
-- MGnify: <https://www.ebi.ac.uk/ena/browser/home>
+- MGnify: <https://www.ebi.ac.uk/metagenomics>
 
 The package is under development, some of the functionality may be very
 limited at this point.


### PR DESCRIPTION
Related to Issue #44.

* Add a new function `ncbi_db_links()` which is a wrapper around `rentrez::entrez_db_links()` which makes use of caching.
* Use `ncbi_db_links()` instead of `ncbi_dbs()` when validating the `to` argument of `ncbi_link_uid()`.
* Fix a README url typo.