### PR TITLE
Guess database from input with ncbi_parse()

### DIFF
--- a/R/ncbi_get_meta.R
+++ b/R/ncbi_get_meta.R
@@ -1,37 +1,34 @@
 #' Get sequence metadata from NCBI
 #' 
-#' This function retrieves metadata from a given NCBI sequence database.
+#' This function retrieves sequence metadata from a given NCBI sequence
+#' database.
 #' @param query either an object of class \code{ncbi_uid} or an integer vector 
 #' of UIDs. See Details for more information.
 #' @param db character; the database to search in. For options see
-#' \code{ncbi_dbs()}. Not all databases are supported.
+#' \code{ncbi_dbs()}. Note that not all of these databases are supported.
 #' @param batch_size integer; the number of search terms to query at once. If
 #' the number of search terms is larger than \code{batch_size}, the search terms
 #' are split into batches and queried separately.
 #' @param use_history logical; should the function use web history for faster
 #' API queries?
-#' @param parse logical; Should the function attempt to parse the output into a
-#' tibble? If unsuccessful, the function will return the unparsed output.
+#' @param parse logical; should the function attempt to parse the output into a
+#' tibble?
 #' @param verbose logical; Should verbose messages be printed to console?
-#' @return The function returns a list with two elements:
-#' \itemize{
-#' \item \code{meta}: if \code{parse = TRUE} then either a tibble with the 
-#' metadata or if parsing is unsuccessful, the unparsed metadata. If
-#' \code{parse = FALSE} the unparsed metadata.
-#' \item \code{history}: a tibble of web histories.
-#' }
-#' @details Some functions in webseq, e.g. \code{ncbi_get_uid()} or
-#' \code{ncbi_link_uid()} return objects of class \code{"ncbi_uid"}. These
-#' objects may be used directly as query input for \code{ncbi_get_meta()}. This
-#' approach is recommended because the internal structure of these objects make
-#' \code{ncbi_get_meta()} queries more robust. Alternatively, you can also
-#' use a character vector of UIDs as query input.
-#' @details If query is a \code{"ncbi_uid"} object, the \code{db} argument is
-#' optional. If \code{db} is not specified, the function will use the
-#' \code{db} attribute of the \code{"ncbi_uid"} object as \code{db} argument.
-#' However, if it is specified, it must be identical to the \code{db} attribute
-#' of the \code{"ncbi_uid"} object. If query is a character vector, the
-#' \code{db} argument is required.
+#' @return If \code(parse = FALSE) the function will return an object of class
+#' \code{ncbi_meta}, which is a character vector with some extra information
+#' about the database. This output can be used directly with \code{ncbi_parse}.
+#' If \code{parse = TRUE} the function will attempt to parse the data using 
+#' \code{ncbi_parse}. If parsing is successful, the function will return a
+#' tibble, otherwise it will return the unparsed \code{ncbi_meta} object.
+#' @details You can give UIDs to \code{ncbi_get_meta()} in two ways: 1. You can
+#' use functions like \code{ncbi_get_uid()} or \code{ncbi_link_uid} to get UIDs,
+#' and then use the returned \code{ncbi_uid} objects directly with
+#' \code{ncbi_get_meta}. If you follow this approach then you do not have to
+#' specify the \code{db} argument since the function can extract it from the
+#' \code{ncbi_uid} object. However, if you do provide it, then it must be
+#' identical to the \code{db} attribute of the \code{"ncbi_uid"} object. 2. 
+#' Alternatively, you can just provide a vector of UIDs, but then you must 
+#' specify the \code{db} argument as well.
 #' @examples
 #' \dontrun{
 #' data(examples)
@@ -155,11 +152,14 @@ ncbi_get_meta <- function(
       foo_from_ids(x, db = db)
     })
   }
+  attr(res, "db") = db
+  class(res) <- c("ncbi_meta", class(res))
+  validate_webseq_class(res)
   if (parse) {
     if (verbose) {
       message("Attempting to parse retrieved metadata.")
     }
-    res_parsed <- ncbi_parse(meta = res, db = db, verbose = verbose)
+    res_parsed <- ncbi_parse(meta = res, verbose = verbose)
     if (all("data.frame" %in% class(res_parsed))) {
       out <- dplyr::bind_rows(res_parsed)
       if (verbose) message("Done.")
@@ -170,8 +170,5 @@ ncbi_get_meta <- function(
   } else {
     out <- res
   }
-  attr(out, "db") = db
-  class(out) <- c("ncbi_meta", class(out))
-  validate_webseq_class(out)
   return(out)
 }

--- a/R/ncbi_parse.R
+++ b/R/ncbi_parse.R
@@ -16,6 +16,12 @@
 #' be used  separately e.g. when you want to examine the unparsed metadata
 #' object before parsing, or when you already downloaded the metadata manually
 #' and you just want to parse it into a tabular format.
+#' @details If \code{meta} is an unparsed \code{ncbi_meta} object returned by 
+#' \code{ncbi_get_meta()} then the \code{db} argument is optional. If \code{db} 
+#' is not specified, the function will extract it automatically. However, if it
+#' is specified, it must be identical to the \code{db} attribute of the metadata
+#' object. If \code{meta} is not an \code{ncbi_meta} object, the \code{db}
+#' argument is required.
 #' @examples
 #' \dontrun{
 #' data(examples)
@@ -32,8 +38,8 @@
 #' 
 #' # Get metadata but do not parse
 #' meta <- ncbi_get_meta(examples$biosample, db = "biosample", parse = FALSE)
-#' # Parse metadata separately
-#' ncbi_parse(meta = meta, db = "biosample", format = "xml")
+#' # Parse metadata separately, the function will extract 'db' automatically.
+#' ncbi_parse(meta = meta)
 #' 
 #' # NCBI BioSample, download XML file from NCBI and parse
 #' 
@@ -41,15 +47,28 @@
 #' # https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN02714232
 #' # upper right corner -> send to -> file -> format = full (xml) -> create file
 #' # Parse XML
-#' ncbi_parse(meta = "biosample_result.xml", db = "biosample", format = "xml")#' 
+#' ncbi_parse(meta = "biosample_result.xml", db = "biosample", format = "xml") 
 #' }
 #' @export
 ncbi_parse <- function(
   meta,
-  db,
+  db = NULL,
   format = "xml",
   verbose = getOption("verbose")
 ) {
+  if ("ncbi_meta" %in% class(meta)) {
+    if (is.null(db)) {
+      db <- attributes(meta)$db
+    } else {
+      if (db != attributes(meta)$db) {
+        msg <- paste0(
+          "'db' for retrieved meta data does not match 'db' argument.\n",
+          "Provide identical values or use db = NULL (default)."
+        )
+        stop(msg)
+      }
+    }
+  }
   db <- match.arg(db, choices = c("assembly", "biosample"))
   format <- match.arg(format, choices = c("xml"))
   f <- get(paste("ncbi_parse", db, format, sep = "_"))

--- a/man/ncbi_get_meta.Rd
+++ b/man/ncbi_get_meta.Rd
@@ -18,7 +18,7 @@ ncbi_get_meta(
 of UIDs. See Details for more information.}
 
 \item{db}{character; the database to search in. For options see
-\code{ncbi_dbs()}. Not all databases are supported.}
+\code{ncbi_dbs()}. Note that not all of these databases are supported.}
 
 \item{batch_size}{integer; the number of search terms to query at once. If
 the number of search terms is larger than \code{batch_size}, the search terms
@@ -27,37 +27,33 @@ are split into batches and queried separately.}
 \item{use_history}{logical; should the function use web history for faster
 API queries?}
 
-\item{parse}{logical; Should the function attempt to parse the output into a
-tibble? If unsuccessful, the function will return the unparsed output.}
+\item{parse}{logical; should the function attempt to parse the output into a
+tibble?}
 
 \item{verbose}{logical; Should verbose messages be printed to console?}
 }
 \value{
-The function returns a list with two elements:
-\itemize{
-\item \code{meta}: if \code{parse = TRUE} then either a tibble with the 
-metadata or if parsing is unsuccessful, the unparsed metadata. If
-\code{parse = FALSE} the unparsed metadata.
-\item \code{history}: a tibble of web histories.
-}
+If \code(parse = FALSE) the function will return an object of class
+\code{ncbi_meta}, which is a character vector with some extra information
+about the database. This output can be used directly with \code{ncbi_parse}.
+If \code{parse = TRUE} the function will attempt to parse the data using 
+\code{ncbi_parse}. If parsing is successful, the function will return a
+tibble, otherwise it will return the unparsed \code{ncbi_meta} object.
 }
 \description{
-This function retrieves metadata from a given NCBI sequence database.
+This function retrieves sequence metadata from a given NCBI sequence
+database.
 }
 \details{
-Some functions in webseq, e.g. \code{ncbi_get_uid()} or
-\code{ncbi_link_uid()} return objects of class \code{"ncbi_uid"}. These
-objects may be used directly as query input for \code{ncbi_get_meta()}. This
-approach is recommended because the internal structure of these objects make
-\code{ncbi_get_meta()} queries more robust. Alternatively, you can also
-use a character vector of UIDs as query input.
-
-If query is a \code{"ncbi_uid"} object, the \code{db} argument is
-optional. If \code{db} is not specified, the function will use the
-\code{db} attribute of the \code{"ncbi_uid"} object as \code{db} argument.
-However, if it is specified, it must be identical to the \code{db} attribute
-of the \code{"ncbi_uid"} object. If query is a character vector, the
-\code{db} argument is required.
+You can give UIDs to \code{ncbi_get_meta()} in two ways: 1. You can
+use functions like \code{ncbi_get_uid()} or \code{ncbi_link_uid} to get UIDs,
+and then use the returned \code{ncbi_uid} objects directly with
+\code{ncbi_get_meta}. If you follow this approach then you do not have to
+specify the \code{db} argument since the function can extract it from the
+\code{ncbi_uid} object. However, if you do provide it, then it must be
+identical to the \code{db} attribute of the \code{"ncbi_uid"} object. 2. 
+Alternatively, you can just provide a vector of UIDs, but then you must 
+specify the \code{db} argument as well.
 }
 \examples{
 \dontrun{

--- a/man/ncbi_parse.Rd
+++ b/man/ncbi_parse.Rd
@@ -4,7 +4,7 @@
 \alias{ncbi_parse}
 \title{Parse NCBI sequence metadata}
 \usage{
-ncbi_parse(meta, db, format = "xml", verbose = getOption("verbose"))
+ncbi_parse(meta, db = NULL, format = "xml", verbose = getOption("verbose"))
 }
 \arguments{
 \item{meta}{character; either an unparsed metadata object returned by
@@ -32,6 +32,13 @@ called automatically if \code{parse = TRUE} (default). However, it can also
 be used  separately e.g. when you want to examine the unparsed metadata
 object before parsing, or when you already downloaded the metadata manually
 and you just want to parse it into a tabular format.
+
+If \code{meta} is an unparsed \code{ncbi_meta} object returned by 
+\code{ncbi_get_meta()} then the \code{db} argument is optional. If \code{db} 
+is not specified, the function will extract it automatically. However, if it
+is specified, it must be identical to the \code{db} attribute of the metadata
+object. If \code{meta} is not an \code{ncbi_meta} object, the \code{db}
+argument is required.
 }
 \examples{
 \dontrun{
@@ -49,8 +56,8 @@ ncbi_parse(meta = "assembly_summary.xml", db = "assembly", format = "xml")
 
 # Get metadata but do not parse
 meta <- ncbi_get_meta(examples$biosample, db = "biosample", parse = FALSE)
-# Parse metadata separately
-ncbi_parse(meta = meta, db = "biosample", format = "xml")
+# Parse metadata separately, the function will extract 'db' automatically.
+ncbi_parse(meta = meta)
 
 # NCBI BioSample, download XML file from NCBI and parse
 
@@ -58,6 +65,6 @@ ncbi_parse(meta = meta, db = "biosample", format = "xml")
 # https://www.ncbi.nlm.nih.gov/biosample/?term=SAMN02714232
 # upper right corner -> send to -> file -> format = full (xml) -> create file
 # Parse XML
-ncbi_parse(meta = "biosample_result.xml", db = "biosample", format = "xml")#' 
+ncbi_parse(meta = "biosample_result.xml", db = "biosample", format = "xml") 
 }
 }


### PR DESCRIPTION
Related to Issue #33, Issue #26.

`ncbi_parse()` will look at the class of the `meta` argument. If it is `ncbi_meta` (unparsed metadata object returned by `ncbi_get_meta()`) and `db` was not specified it will extract the name of the database from the object. If `db` was specified it will check whether they are identical and stop if they are not. It `meta` is not an `ncbi_meta` object, the function will require a `db` argument.