### PR TITLE
Update ncbi_download_genome()

### DIFF
--- a/R/ncbi_download_genome.R
+++ b/R/ncbi_download_genome.R
@@ -52,13 +52,11 @@ ncbi_download_genome <- function(query,
   } else {
     assembly_uid <- query
   }
-  assembly_uid <- as.numeric(assembly_uid)
-  if (all(is.na(assembly_uid))) {
-    stop("No valid UIDs.")
-  } else if (any(is.na(assembly_uid))){
-    if (verbose) message("Removing NA-s from IDs.")
-    assembly_uid <- assembly_uid[which(!is.na(assembly_uid))]
-  }
+  assembly_uid <- unlist(get_idlist(
+    assembly_uid, 
+    batch_size = length(assembly_uid),
+    verbose = verbose
+  ))
   foo <- function(x, type, verbose) {
     if (verbose) message(x, ". ", appendLF = FALSE)
     # TODO update ncbi_parse_assembly_xml and then replace ncbi_meta_assembly()
@@ -109,7 +107,7 @@ ncbi_download_genome <- function(query,
       if (verbose) message("Done. Already downloaded.")
       return(NA)
     }
-    Sys.sleep(stats::runif(1,0.2,0.5))
+    webseq_sleep(type = "FTP")
     out <- try(utils::download.file(urlpath,
                                     destfile = filepath,
                                     quiet = TRUE), silent = TRUE)

--- a/R/ncbi_download_genome.R
+++ b/R/ncbi_download_genome.R
@@ -10,6 +10,8 @@
 #' \code{"protein.faa"}, \code{"protein.gpff"}, \code{"translated_cds"}.
 #' @param dirpath character; the path to the directory where the file should be
 #' downloaded. If \code{NULL}, download file to the working directory.
+#' @param mirror logical; should the download directory mirror the structure of 
+#' the FTP directory?
 #' @param verbose logical; should verbose messages be printed to console?
 #' @details Some functions in webseq, e.g. \code{ncbi_get_uid()} or
 #' \code{ncbi_link_uid()} return objects of class \code{"ncbi_uid"}. These
@@ -38,6 +40,7 @@
 ncbi_download_genome <- function(query,
                                  type = "genomic.gbff",
                                  dirpath = NULL,
+                                 mirror = TRUE,
                                  verbose = getOption("verbose")) {
   type <- match.arg(type, c(
     "assembly_report", "assembly_stats", "cds", "feature_count",
@@ -101,6 +104,13 @@ ncbi_download_genome <- function(query,
                      translated_cds = ".faa.gz")
     urlpath <- paste0(ftppath, "/", prefix, "_" ,type, suffix)
     if (is.null(dirpath)) dirpath = getwd()
+    if (mirror) {
+      dirpath <- gsub(
+        "ftp://ftp.ncbi.nlm.nih.gov/genomes",
+        dirpath,
+        ftppath
+      )
+    }
     if (!dir.exists(dirpath)) dir.create(dirpath, recursive = TRUE)
     filepath <- paste0(dirpath, "/", basename(urlpath))
     if (file.exists(filepath)) {

--- a/R/ncbi_get_meta.R
+++ b/R/ncbi_get_meta.R
@@ -14,7 +14,7 @@
 #' @param parse logical; should the function attempt to parse the output into a
 #' tibble?
 #' @param verbose logical; Should verbose messages be printed to console?
-#' @return If \code(parse = FALSE) the function will return an object of class
+#' @return If \code{parse = FALSE} the function will return an object of class
 #' \code{ncbi_meta}, which is a character vector with some extra information
 #' about the database. This output can be used directly with \code{ncbi_parse}.
 #' If \code{parse = TRUE} the function will attempt to parse the data using 

--- a/R/utils.R
+++ b/R/utils.R
@@ -41,11 +41,14 @@ webseq_message <- function(action = c("na",
 #' @param type character; Will be an API queried or a website scraped?
 #' @noRd
 #'
-webseq_sleep <- function(time = NULL, type = c('API', 'scrape')) {
+webseq_sleep <- function(time = NULL, type = c("API", "FTP", "scrape")) {
   type <- match.arg(type)
   if (is.null(time)) {
     if (type == 'API') {
       time <- 0.2
+    }
+    if (type == "FTP") {
+      time <- 0.1
     }
     if (type == 'scrape') {
       time <- 0.3

--- a/man/ncbi_download_genome.Rd
+++ b/man/ncbi_download_genome.Rd
@@ -8,6 +8,7 @@ ncbi_download_genome(
   query,
   type = "genomic.gbff",
   dirpath = NULL,
+  mirror = TRUE,
   verbose = getOption("verbose")
 )
 }
@@ -23,6 +24,9 @@ of NCBI Assembly UIDs. See Details for more information.}
 
 \item{dirpath}{character; the path to the directory where the file should be
 downloaded. If \code{NULL}, download file to the working directory.}
+
+\item{mirror}{logical; should the download directory mirror the structure of 
+the FTP directory?}
 
 \item{verbose}{logical; should verbose messages be printed to console?}
 }

--- a/man/ncbi_download_genome.Rd
+++ b/man/ncbi_download_genome.Rd
@@ -2,17 +2,18 @@
 % Please edit documentation in R/ncbi_download_genome.R
 \name{ncbi_download_genome}
 \alias{ncbi_download_genome}
-\title{Download Genomes from NCBI}
+\title{Download Genomes from NCBI Assembly Database}
 \usage{
 ncbi_download_genome(
-  accession,
+  query,
   type = "genomic.gbff",
   dirpath = NULL,
   verbose = getOption("verbose")
 )
 }
 \arguments{
-\item{accession}{character; a character vector of assembly accessions.}
+\item{query}{either an object of class \code{ncbi_uid} or an integer vector 
+of NCBI Assembly UIDs. See Details for more information.}
 
 \item{type}{character; the file extension to download. Valid options are
 \code{"assembly_report"}, \code{"assembly_stats"}, \code{"cds"},
@@ -28,15 +29,29 @@ downloaded. If \code{NULL}, download file to the working directory.}
 \description{
 This function directly downloads genome data through the NCBI FTP server.
 }
+\details{
+Some functions in webseq, e.g. \code{ncbi_get_uid()} or
+\code{ncbi_link_uid()} return objects of class \code{"ncbi_uid"}. These
+objects may be used directly as query input for
+\code{ncbi_download_genome()}. It is recommended to use this approach because
+then the function will check whether the query really contains UIDs from the
+NCBI Assembly database and fail if not. Alternatively, you can also use a
+character vector of UIDs as query input but in this case there will be no
+consistency checks and the function will just attempt to interpret them as
+NCBI Assembly UIDs.
+}
 \examples{
 \dontrun{
 # Download genbank file for GCF_003007635.1.
 # The function will access files within this directory:
 # ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/003/007/635/
-ncbi_download_genome("GCF_003007635.1", type = "genomic.gbff", verbose = TRUE)
+
+uid <- ncbi_get_uid("GCF_003007635.1", db = "assembly")
+ncbi_download_genome(uid, type = "genomic.gbff", verbose = TRUE)
 
 # Download multiple files
-accessions <- c("GCF_000248195.1", "GCF_000695855.3")
-ncbi_download_genome(accessions, type = "genomic.gbff", verbose = TRUE)
+data(examples) 
+uids <- ncbi_get_uid(examples$assembly, db = "assembly")
+ncbi_download_genome(uids, type = "genomic.gff", verbose = TRUE)
 }
 }

--- a/man/ncbi_get_meta.Rd
+++ b/man/ncbi_get_meta.Rd
@@ -33,7 +33,7 @@ tibble?}
 \item{verbose}{logical; Should verbose messages be printed to console?}
 }
 \value{
-If \code(parse = FALSE) the function will return an object of class
+If \code{parse = FALSE} the function will return an object of class
 \code{ncbi_meta}, which is a character vector with some extra information
 about the database. This output can be used directly with \code{ncbi_parse}.
 If \code{parse = TRUE} the function will attempt to parse the data using 


### PR DESCRIPTION
Related to Issue #11, Issue #16, Issue #26.

* The function used to require GCA/GCF accessions the PR changes this to either an `ncbi_uid` object or a vector or UIDs. This speeds up the function because previously, converting 100 accessions to 100 UIDs required 100 `ncbi_get_uid()` calls. Now the user can make a single `ncbi_get_uid()` call and give the output to `ncbi_download_genome()`.
* The above change also integrates `ncbi_download_genome()` more with other `webseq` functions. The function will check whether the UIDs are from the NCBI Assembly database and stop if not.
*  Add new argument `mirror` which controls whether NCBI's FTP structure should be mirrored.