### PR TITLE
Enable parallelisation for Windows

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -153,6 +153,8 @@ validate_webseq_class <- function(x) {
 #' @param verbose logical; Should verbose messages be printed to console?
 #' @noRd
 get_mc_cores <- function(mc_cores, verbose = getOption("verbose")) {
+  n_cores <- parallel::detectCores()
+  if (is.na(n_cores)) stop("Could not detect number of cores.")
   if (is.null(mc_cores)) {
     if (verbose) message(
       "Number of cores not specified. Looking at 'Ncpu' option."
@@ -164,21 +166,26 @@ get_mc_cores <- function(mc_cores, verbose = getOption("verbose")) {
       if (verbose) message(
         "Not found. Attempting to use all but one cores (at least 1)."
       )
-      mc_cores <- max(parallel::detectCores() - 1, 1)
+      mc_cores <- max(n_cores - 1, 1)
     }
   }
-  mc_cores <- as.integer(mc_cores)
-  if (!is.integer(mc_cores)) {
-    stop("Number of cores must be an integer.")
+  mc_cores <- suppressWarnings(as.integer(mc_cores))
+  if (is.na(mc_cores)) {
+    stop("Number of cores must be an integer, or coercible to an integer.")
   }
   if (mc_cores < 1) {
     stop("Number of cores must be at least 1.")
   }
+  if (mc_cores > n_cores) {
+    if (verbose) message(
+      "Number of cores specified is greater than the number of available ",
+      "cores. Using all available cores."
+    )
+    mc_cores <- n_cores
+  }
   sys <- Sys.info()
   if (mc_cores > 1 && sys[["sysname"]] == "Windows") {
-    if (verbose) message(
-      "'mc.cores' > 1 is not supported on Windows."
-    )
+    if (verbose) message("'mc.cores' > 1 is not supported on Windows.")
     mc_cores <- 1
   }
   return(mc_cores)

--- a/R/utils.R
+++ b/R/utils.R
@@ -183,10 +183,5 @@ get_mc_cores <- function(mc_cores, verbose = getOption("verbose")) {
     )
     mc_cores <- n_cores
   }
-  sys <- Sys.info()
-  if (mc_cores > 1 && sys[["sysname"]] == "Windows") {
-    if (verbose) message("'mc.cores' > 1 is not supported on Windows.")
-    mc_cores <- 1
-  }
   return(mc_cores)
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get install -y \
   r-cran-xml2
 
 # Install webseq
-RUN R -e 'options(warn = 2); devtools::install_github("stitam/webseq", upgrade = "never")'
+RUN R -e 'options(warn = 2); devtools::install_github("stitam/webseq", force = TRUE, upgrade = "never")'
 
 # Set R library path to avoid binding from host system
 ENV R_LIBS_USER /usr/local/lib/R/site-library


### PR DESCRIPTION
Related to issue #68.

Previously the packages used `parallel::mclapply()` for parallelisation but apparently this is does not work on Windows. As an immediate workaround parallelisation was disabled for Windows but this is a poor outcome.

This PR updates parallelisation such that it keeps the "fork" approach for non-Windows systems and implements the "socket" approach for Windows. Reference: https://dept.stat.lsa.umich.edu/~jerrick/courses/stat701/notes/parallel.html

The PR also includes a small but important change to the Dockerfile which ensures that`webseq()` is updated each time the container is built.