### PR TITLE
Convert UIDs to numeric instead of integer

### DIFF
--- a/R/ncbi_get_uid.R
+++ b/R/ncbi_get_uid.R
@@ -80,27 +80,27 @@ ncbi_get_uid <- function(
     }
     if (length(hit) == 1 && is.na(hit)) {
       return(list(
-        uid = NA_integer_,
+        uid = NA_real_,
         db = db,
         web_history = tibble::tibble()
       ))
     } else if (length(hit$ids) == 0) {
       if (verbose) message("Term not found. Returning NA.")
       return(list(
-        uid = NA_integer_,
+        uid = NA_real_,
         db = db,
         web_history = tibble::tibble()
       ))
     } else if (length(hit$ids) > 0) {
       return(list(
-        uid = as.integer(hit$ids),
+        uid = as.numeric(hit$ids),
         db = db,
         web_history = hit$web_history
       ))
     } else {
       if (verbose) message("Unknown exception.")
       return(list(
-        uid = NA_integer_,
+        uid = NA_real_,
         db = db,
         web_history = tibble::tibble()
       ))

--- a/R/ncbi_link_uid.R
+++ b/R/ncbi_link_uid.R
@@ -105,13 +105,13 @@ ncbi_link_uid <- function(
       (length(wh_hit) == 1 && is.na(wh_hit))
       ) {
       return(list(
-        uid = NA_integer_,
+        uid = NA_real_,
         db = to,
         web_history = tibble::tibble()
       ))
     } else {
       return(list(
-        uid = as.integer(id_hit$links[[paste(from, to, sep = "_")]]),
+        uid = as.numeric(id_hit$links[[paste(from, to, sep = "_")]]),
         db = to,
         web_history = wh_hit$web_histories[[paste(from, to, sep = "_")]]
       ))
@@ -121,7 +121,7 @@ ncbi_link_uid <- function(
     if (length(x) == 1 && is.na(x)) {
       if (verbose) message("No valid UIDs.")
       return(list(
-        uid = NA_integer_,
+        uid = NA_real_,
         db = to,
         web_history = tibble::tibble()
       ))
@@ -153,7 +153,7 @@ ncbi_link_uid <- function(
       (length(wh_hit) == 1 && is.na(wh_hit))
       ) {
       return(list(
-        uid = NA_integer_,
+        uid = NA_real_,
         db = to,
         web_history = tibble::tibble()
       ))
@@ -164,7 +164,7 @@ ncbi_link_uid <- function(
         web_history <- wh_hit$web_histories[[paste(from, to, sep = "_")]]
       }
       return(list(
-        uid = as.integer(id_hit$links[[paste(from, to, sep = "_")]]),
+        uid = as.numeric(id_hit$links[[paste(from, to, sep = "_")]]),
         db = to,
         web_history = web_history
       ))

--- a/R/utils.R
+++ b/R/utils.R
@@ -158,7 +158,7 @@ validate_webseq_class <- function(x) {
     testthat::expect_true(names(x)[1] == "uid")
     testthat::expect_true(names(x)[2] == "db")
     testthat::expect_true(names(x)[3] == "web_history")
-    testthat::expect_true(class(x$uid) == "integer")
+    testthat::expect_true(class(x$uid) == "numeric")
     testthat::expect_true(class(x$db) == "character")
     testthat::expect_s3_class(x$web_history, c("tbl_df", "tbl", "data.frame"))
   }

--- a/tests/testthat/test-ncbi_link_uid.R
+++ b/tests/testthat/test-ncbi_link_uid.R
@@ -76,5 +76,12 @@ test_that("ncbi_link_uid() can use an ncbi_uid object's db element", {
 test_that("ncbi_link_uid() returns NA if input is invalid", {
   expect_equal(suppressWarnings(
     ncbi_link_uid("funky", from = "assembly", to = "biosample")$uid
-  ), NA_integer_)
+  ), NA_real_)
+})
+
+# issue 72
+test_that("ncbi_link_uid() converts UIDs to numeric without coercion to NA", {
+  nuccore_uid <- ncbi_link_uid(488139305, from = "protein", to = "nuccore")
+  
+  expect_equal(sum(is.na(nuccore_uid$uid)), 0)
 })


### PR DESCRIPTION
Related to issue #72.

Converting UID strings to integers created NAs. Replacing `as.integer()` with `as.numeric()` seems to have solved the issue.