### PR TITLE
Update existing NCBI functions

### DIFF
--- a/R/ncbi_download_genome.R
+++ b/R/ncbi_download_genome.R
@@ -60,13 +60,13 @@ ncbi_download_genome <- function(query,
       stop("'ncbi_uid' object must contain NCBI Assembly UIDs.")
     }
   } else if ("ncbi_uid_link" %in% class(query)) {
-    if (names(query)[2] == "assembly") {
+    if (names(query)[length(names(query))] == "assembly") {
       assembly_uid <- unique(query$assembly)
     } else {
       stop("'ncbi_uid_link' object must contain links to NCBI Assembly UIDs.")
     }
   } else if ("ncbi_link" %in% class(query)) {
-    if (names(query)[2] == "assembly") {
+    if (names(query)[length(names(query))] == "assembly") {
       assembly_uid <- ncbi_get_uid(query$assembly, db = "assembly")$uid
     } else {
       stop("'ncbi_link' object must contain links to NCBI Assembly IDs.")

--- a/R/ncbi_link.R
+++ b/R/ncbi_link.R
@@ -9,6 +9,8 @@
 #' \code{ncbi_dbs()} lists all available options.
 #' @param to character; the database in which the function should look for links.
 #' \code{ncbi_dbs()} lists all available options.
+#' @param multiple character; handling of rows in x with multiple matches in y.
+#' For more information see `?dplyr::left_join()`.
 #' @param batch_size integer; the number of search terms to query at once. If
 #' the number of search terms is larger than \code{batch_size}, the search terms
 #' are split into batches and queried separately.

--- a/R/ncbi_link_uid.R
+++ b/R/ncbi_link_uid.R
@@ -113,5 +113,6 @@ ncbi_link_uid <- function(
     out <- dplyr::left_join(tibble::tibble(query = query), out, by = "query")
   }
   names(out) <- c(from, to)
+  class(out) <- c("ncbi_uid_link", class(out))
   return(out)
 }

--- a/R/ncbi_recover_id.R
+++ b/R/ncbi_recover_id.R
@@ -60,6 +60,8 @@ ncbi_recover_id <- function(
     id <- unname(sapply(summaries, function(x) x$project_acc))
   } else if (db == "gene") {
     id <- unname(sapply(summaries, function(x) x$uid))
+  } else if (db == "nuccore") {
+    id <- unname(sapply(summaries, function(x) x$accessionversion))
   } else if (db == "protein") {
     id <- unname(sapply(summaries, function(x) x$accessionversion))
   } else {

--- a/man/ncbi_download_genome.Rd
+++ b/man/ncbi_download_genome.Rd
@@ -6,15 +6,15 @@
 \usage{
 ncbi_download_genome(
   query,
-  type = "genomic.gbff",
+  type = "genomic.fna",
   dirpath = NULL,
-  mirror = TRUE,
+  mirror = FALSE,
   verbose = getOption("verbose")
 )
 }
 \arguments{
-\item{query}{either an object of class \code{ncbi_uid} or an integer vector 
-of NCBI Assembly UIDs. See Details for more information.}
+\item{query}{an object of class `ncbi_uid`, `ncbi_uid_link`, `ncbi_link`, or 
+an integer vector of NCBI Assembly UIDs. See Details for more information.}
 
 \item{type}{character; the file extension to download. Valid options are
 \code{"assembly_report"}, \code{"assembly_stats"}, \code{"cds"},
@@ -34,28 +34,35 @@ the FTP directory?}
 This function directly downloads genome data through the NCBI FTP server.
 }
 \details{
-Some functions in webseq, e.g. \code{ncbi_get_uid()} or
-\code{ncbi_link_uid()} return objects of class \code{"ncbi_uid"}. These
-objects may be used directly as query input for
-\code{ncbi_download_genome()}. It is recommended to use this approach because
-then the function will check whether the query really contains UIDs from the
-NCBI Assembly database and fail if not. Alternatively, you can also use a
-character vector of UIDs as query input but in this case there will be no
-consistency checks and the function will just attempt to interpret them as
-NCBI Assembly UIDs.
+`ncbi_get_uid()` returns an object of class `ncbi_uid`; 
+`ncbi_link_uid` returns an object of class `ncbi_uid_link`; `ncbi_link`
+returns and object of class `ncbi_link`. These objects may be used directly 
+as query input for `ncbi_download_genome`. It is recommended to use this
+approach. Alternatively, you can also use a character vector of UIDs as query
+input.  This approach is not recommended because there are no consistency 
+checks, the function will just attempt to interpret the query as NCBI 
+Assembly UIDs.
 }
 \examples{
 \dontrun{
-# Download genbank file for GCF_003007635.1.
-# The function will access files within this directory:
-# ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/003/007/635/
+# Download a single genome
+ncbi_get_uid("GCF_003007635.1", db = "assembly") |>
+  ncbi_download_genome()
 
-uid <- ncbi_get_uid("GCF_003007635.1", db = "assembly")
-ncbi_download_genome(uid, type = "genomic.gbff", verbose = TRUE)
+"SAMN08619567" |>
+  ncbi_get_uid(db = "biosample") |>
+  ncbi_link_uid(to = "assembly") |>
+  ncbi_download_genome()
+  
+"SAMN08619567" |>
+  ncbi_link(from = "biosample", to = "assembly") |>
+  ncbi_download_genome()
 
-# Download multiple files
+# Download multiple genomes, mirror FTP directory structure
 data(examples) 
-uids <- ncbi_get_uid(examples$assembly, db = "assembly")
-ncbi_download_genome(uids, type = "genomic.gff", verbose = TRUE)
+
+examples$assembly |> 
+  ncbi_get_uid(db = "assembly") |>
+  ncbi_download_genome()
 }
 }

--- a/man/ncbi_get_uid.Rd
+++ b/man/ncbi_get_uid.Rd
@@ -9,6 +9,7 @@ ncbi_get_uid(
   db,
   batch_size = 100,
   use_history = TRUE,
+  na_strings = "NA",
   verbose = getOption("verbose")
 )
 }
@@ -24,6 +25,9 @@ are split into batches and queried separately.}
 
 \item{use_history}{logical; should the function use web history for faster
 API queries?}
+
+\item{na_strings}{character; a vector of strings which should be interpreted
+as `NA`.}
 
 \item{verbose}{logical; should verbose messages be printed to the console?}
 }

--- a/man/ncbi_link.Rd
+++ b/man/ncbi_link.Rd
@@ -22,6 +22,9 @@ ncbi_link(
 \item{to}{character; the database in which the function should look for links.
 \code{ncbi_dbs()} lists all available options.}
 
+\item{multiple}{character; handling of rows in x with multiple matches in y.
+For more information see `?dplyr::left_join()`.}
+
 \item{batch_size}{integer; the number of search terms to query at once. If
 the number of search terms is larger than \code{batch_size}, the search terms
 are split into batches and queried separately.}

--- a/man/ncbi_link.Rd
+++ b/man/ncbi_link.Rd
@@ -4,7 +4,14 @@
 \alias{ncbi_link}
 \title{Link ID-s from one NCBI database to another}
 \usage{
-ncbi_link(query, from, to, batch_size = 100, verbose = getOption("verbose"))
+ncbi_link(
+  query,
+  from,
+  to,
+  multiple = "all",
+  batch_size = 100,
+  verbose = getOption("verbose")
+)
 }
 \arguments{
 \item{query}{character; a vector of IDs}

--- a/man/ncbi_link_uid.Rd
+++ b/man/ncbi_link_uid.Rd
@@ -13,26 +13,30 @@ ncbi_link_uid(
 )
 }
 \arguments{
-\item{query}{either an object of class \code{ncbi_uid} or an integer vector 
-of UIDs. See Details for more information.}
+\item{query}{either an object of class `ncbi_uid` or `ncbi_uid_link`, or an
+integer vector of UIDs. See Details for more information.}
 
 \item{from}{character; the database the queried UIDs come from.
-\code{ncbi_dbs()} lists all available options.}
-
-\item{to}{character; the database in which the function should look for links.
 \code{ncbi_dbs()} lists all available options. See Details for more
 information.}
 
+\item{to}{character; the database in which the function should look for links.
+\code{ncbi_dbs()} lists all available options.}
+
 \item{batch_size}{integer; the number of search terms to query at once. If
 the number of search terms is larger than \code{batch_size}, the search terms
-are split into batches and queried separately. Not used when using web
-history.}
+are split into batches and queried separately.}
 
 \item{verbose}{logical; should verbose messages be printed to the console?}
 }
 \value{
-A tibble with two columns. The first column contains UIDs in the 
-`from` database, the second column contains linked UIDs in the `to` database.
+A tibble with two or more columns. When `ncbi_link_uid()` is called
+on a `ncbi_uid` object or a vector of UIDs, the function returns a tibble
+with exactly two columns: the first column contains UIDs in the `from`
+database, and the second column contains linked UIDs in the `to` database.
+However, `ncbi_link_uid()` can be called multiple times in succession. Each
+call after the first call will add a new column to the returned tibble. 
+See Details for more information.
 }
 \description{
 Each entry in an NCBI database has its unique internal id. Entries in
@@ -41,13 +45,28 @@ database may be linked with entries in the NCBI BioSample database. This
 function attempts to link uids from one database to another.
 }
 \details{
-The function `ncbi_get_uid()` returns an object of class `ncbi_uid`. 
-This object may be used directly as query for `ncbi_link_uid()`. If query is 
-an `ncbi_uid` object, the `from` argument is optional. If `from` is not 
-specified, the function will retrieve it from the query object. However, if 
-it is specified, it must be identical to the `db` attribute of the query.
+The function can take three query classes: It can take `ncbi_uid`
+objects, these are returned by `ncbi_get_uid()`. In this case, the `from`
+argument will be retrieved from the query object, by default. It can also
+take `ncbi_uid_link` objects, which means `ncbi_link_uid()` can be called
+several times in a sequence to perform a number of successive conversions.
+When the query is an `ncbi_uid_link` object, the function will always convert
+the UIDs in the last column of the query object, and will retrieve the `from`
+argument from the name of the last column. This means links should always be
+interpreted "left-to-right". Note, when tibbles are joined during subsequent
+`ncbi_link_uid` calls they are joined using "many-to-many" relationships; see
+`?dplyr::left_join()` for more information. Lastly, the function can also
+take a vector of integer UIDs.
 }
 \examples{
+# Simple call with integer UIDs
 ncbi_link_uid(5197591, "assembly", "biosample")
 ncbi_link_uid(c(1226742659, 1883410844), "protein", "nuccore")
+
+# Complex call with ncbi_get_uid() and several ncbi_link_uid() calls
+"GCF_000299415.1" |> 
+  ncbi_get_uid(db = "assembly") |> 
+  ncbi_link_uid(to = "biosample") |>
+  ncbi_link_uid(to = "bioproject") |>
+  ncbi_link_uid(to = "pubmed")
 }

--- a/tests/testthat/test-ncbi_get_uid.R
+++ b/tests/testthat/test-ncbi_get_uid.R
@@ -39,9 +39,10 @@ test_that("ncbi_get_uid() handles NA", {
   expect_true(all(c("ncbi_uid", "list") %in% class(res)))
   expect_equal(length(res$uid), 2)
   
-  expect_true(res_messages[1] == "Removing NA-s from search terms.\n")
-  expect_true(res_messages[2] == "Querying UIDs for batch 1. ")
-  expect_true(res_messages[3] == "Query successful.\n")
+  expect_true(res_messages[1] == "Removing NA-s from search terms. ")
+  expect_true(res_messages[2] == "2 terms remain.\n")
+  expect_true(res_messages[3] == "Querying UIDs for batch 1. ")
+  expect_true(res_messages[4] == "Query successful.\n")
 })
 
 test_that("ncbi_get_uid() handles invalid terms", {
@@ -57,8 +58,13 @@ test_that("ncbi_get_uid() handles invalid terms", {
   expect_equal(nrow(res$web_history), 0)
 })
 
-test_that("ncbi_get_uid works with a complex term", {
+test_that("ncbi_get_uid() works with a complex term", {
   res <- ncbi_get_uid("Autographiviridae OR Podoviridae", db = "assembly")
 
   expect_true(length(res$uid) > 3000)
+})
+
+# issue #80
+test_that("ncbi_get_uid() stops with an error when input is 'NA' (string)", {
+  expect_error(ncbi_get_uid("NA", db = "biosample"))
 })

--- a/tests/testthat/test-ncbi_link_uid.R
+++ b/tests/testthat/test-ncbi_link_uid.R
@@ -64,9 +64,9 @@ test_that("ncbi_link_uid() returns more rows when there are multiple links", {
   query <- "PRJEB54063"
   puid <- ncbi_get_uid(query, db = "bioproject")
   buid <- ncbi_link_uid(puid, to = "biosample")
-  expect_equal(dim(buid), c(2,2))
-  expect_equal(buid$bioproject, c(883889, 883889))
-  expect_equal(buid$biosample, c(31267349, 31250566))
+  expect_equal(dim(buid), c(148,2))
+  expect_equal(buid$bioproject[1:2], c(883889, 883889))
+  expect_equal(buid$biosample[1:2], c(31267349, 31250566))
 })
 
 test_that("ncbi_link_uid() returns results for all valid queries", {
@@ -83,4 +83,24 @@ test_that("ncbi_link_uid() converts UIDs to numeric without coercion to NA", {
   nuccore_uid <- ncbi_link_uid(488139305, from = "protein", to = "nuccore")
   
   expect_equal(sum(is.na(nuccore_uid$nuccore)), 0)
+})
+
+test_that("ncbi_link_uid() works with ncbi_uid_link objects", {
+  pubmed_uid <- "GCF_000299415.1" |> 
+    ncbi_get_uid(db = "assembly") |> 
+    ncbi_link_uid(to = "biosample") |>
+    ncbi_link_uid(to = "bioproject") |>
+    ncbi_link_uid(to = "pubmed")
+  
+  expect_true(inherits(pubmed_uid, "ncbi_uid_link"))
+  expect_true(inherits(pubmed_uid, "data.frame"))
+  expect_equal(dim(pubmed_uid), c(2,4))
+  expect_equal(
+    names(pubmed_uid), 
+    c("assembly", "biosample", "bioproject", "pubmed")
+  )
+  expect_equal(pubmed_uid$assembly, c(623048, 623048))
+  expect_equal(pubmed_uid$biosample, c(1730125, 1730125))
+  expect_equal(pubmed_uid$bioproject, c(224116, 174686))
+  expect_equal(pubmed_uid$pubmed, c(24316578, 23144412))
 })

--- a/tests/testthat/test-ncbi_recover_id.R
+++ b/tests/testthat/test-ncbi_recover_id.R
@@ -21,3 +21,9 @@ test_that("ncbi_recover_id() works with duplicates", {
   
   expect_equal(ids, c("SAMN02597423", "SAMN02597423"))
 })
+
+test_that("ncbi_recover_id() works with nuccore", {
+  uid <- ncbi_get_uid("OP617744.1", db = "nuccore")
+  id <- ncbi_recover_id(uid)
+  expect_equal(id,"OP617744.1")
+})


### PR DESCRIPTION
Related to issue #26, #80, #82.

Changes in `ncbi_get_uid()`:
- Function has a new argument, `na_strings`. The defined NA strings will be converted to `NA`-s and will be removed from the query.

Changes in `ncbi_link_uid()`:
- The function can be called multiple times in a sequence. Each call will take the last column as the query and add a new column. This allows for cleaner workflows using pipe operators.

Changes in `ncbi_link()`:
- The internal dispatch has been simplified. Instead of dispatching to a separate function for each from-to combination, some combinations are now dispatched to a generic link function which seems to work for multiple combinations.

Changes in `ncbi_download_genome()`:
- Changed default arguments: the function will download fasta files instead of genbank files and will no longer mirror FTP structure.
- The function can now be piped with the output of `ncbi_link()` and `ncbi_link_uid()`, if the last column contains assemblies.

Changes in `ncbi_recover_id()`:
- The function can now recover nuccore IDs as well.

Other:
- Updated documentation and added new tests.




