### PR TITLE
Fix ena_query()

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -5,9 +5,10 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
 
-name: test-coverage
+name: test-coverage.yaml
+
+permissions: read-all
 
 jobs:
   test-coverage:
@@ -16,7 +17,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -24,28 +25,39 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr
+          extra-packages: any::covr, any::xml2
           needs: coverage
 
       - name: Test coverage
         run: |
-          covr::codecov(
+          cov <- covr::package_coverage(
             quiet = FALSE,
             clean = FALSE,
-            install_path = file.path(Sys.getenv("RUNNER_TEMP"), "package")
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
+          print(cov)
+          covr::to_cobertura(cov)
         shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v5
+        with:
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          files: ./cobertura.xml
+          plugins: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Show testthat output
         if: always()
         run: |
           ## --------------------------------------------------------------------
-          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
         shell: bash
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,8 @@ Version: 0.1
 Date: 2022-01-05
 Author: Tamas Stirling
 Maintainer: Tamas Stirling <stirling.tamas@gmail.com>
+URL: https://github.com/stitam/webseq
+BugReports: https://github.com/stitam/webseq/issues
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/R/ena_query.R
+++ b/R/ena_query.R
@@ -11,6 +11,7 @@
 #'\code{"batch"}: one file for each batch, \code{"all"}: one file altogether.
 #'@param gzip logical; Download the result as a gzip file.
 #'@param set logical; ???
+#'@param include_links logical; ???
 #'@param range character; ???
 #'@param complement logical; ???
 #'@param batch_size integer; Number of accessions to query in a single request.
@@ -34,6 +35,7 @@ ena_query <- function(
     destfile_by = "all",
     gzip = FALSE,
     set = FALSE,
+    include_links = FALSE,
     range = NULL,
     complement = FALSE,
     batch_size = 0,
@@ -45,6 +47,7 @@ ena_query <- function(
   stopifnot(length(download) == 1 && is.logical(download))
   stopifnot(length(gzip) == 1 && is.logical(gzip))
   stopifnot(length(set) == 1 && is.logical(set))
+  stopifnot(length(include_links) == 1 && is.logical(include_links))
   #stopifnot(length(range) == 1 && is.character(range))
   stopifnot(length(complement) == 1 && is.logical(complement))
   stopifnot(length(verbose) == 1 && is.logical(verbose))
@@ -85,6 +88,7 @@ ena_query <- function(
       "&download=", download,
       "&gzip=", gzip,
       "&set=", set,
+      "&includeLinks=", include_links,
       "&complement=", complement
     )
     if (download == "true") {

--- a/R/utils.R
+++ b/R/utils.R
@@ -4,6 +4,7 @@
 #' return the package URL (the first element of the URL field).
 #'
 #' @return Either a URL
+#' @noRd
 package_url <- function() {
   # Get package name
   ns <- parent.frame()

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,23 @@
+#' Get package URL
+#'
+#' Look up the DESCRIPTION file of the package that called this function and
+#' return the package URL (the first element of the URL field).
+#'
+#' @return Either a URL
+package_url <- function() {
+  # Get package name
+  ns <- parent.frame()
+  pkg <- utils::packageName(ns)
+  if (is.null(pkg)) stop("Could not extract package name.")
+  # Extract URL from DESCRIPTION file
+  desc <- utils::packageDescription(pkg)
+  if (!"URL" %in% names(desc)) stop("Could not extract URL, missing field.")
+  urls <- unlist(strsplit(desc[["URL"]], "[[:space:],]+"))
+  urls <- urls[nzchar(urls)]
+  if (length(urls) == 0) stop("Could not extract URL, empty field.")
+  return(urls[1])
+}
+
 #' Retry a function call
 #' 
 #' @param expr expression; Expression to evaluate.

--- a/man/ena_query.Rd
+++ b/man/ena_query.Rd
@@ -14,6 +14,7 @@ ena_query(
   destfile_by = "all",
   gzip = FALSE,
   set = FALSE,
+  include_links = FALSE,
   range = NULL,
   complement = FALSE,
   batch_size = 0,
@@ -40,6 +41,8 @@ ena_query(
 \item{gzip}{logical; Download the result as a gzip file.}
 
 \item{set}{logical; ???}
+
+\item{include_links}{logical; ???}
 
 \item{range}{character; ???}
 


### PR DESCRIPTION
Related to #101.

This PR:

* Adds a new argument `include_links` to `ena_query()`.
* Updates the obsolete (I think) syntax which used a single url to the header, body, etc. syntax, which fixes the issue.
* Adds a convenience function `project_url()` which always returns the project URL for the package in which it was called.
* Adds `project_url()` to API requests to identify the package to the web API, avoiding anonymous requests.